### PR TITLE
Adding foreman + ovirt + salt workflow digram

### DIFF
--- a/_includes/manuals/1.7/2.1_quickstart_installation.md
+++ b/_includes/manuals/1.7/2.1_quickstart_installation.md
@@ -98,7 +98,7 @@ rpm -ivh http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
   <p>Enable the EPEL (Extra Packages for Enterprise Linux) and the Foreman repos:</p>
 
 {% highlight bash %}
-rpm -ivh http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-2.noarch.rpm
+rpm -ivh http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
 yum -y install http://yum.theforeman.org/releases/{{page.version}}/el7/x86_64/foreman-release.rpm
 {% endhighlight %}
 </div>

--- a/_includes/manuals/1.7/4.3.5.2_isc_dhcp.md
+++ b/_includes/manuals/1.7/4.3.5.2_isc_dhcp.md
@@ -19,7 +19,7 @@ The dhcpd api server will listen to any host. You might need to add a omapi_key 
 
 Example generating a key (on CentOS):
 <pre>
-yum install bind97
+yum install bind
 dnssec-keygen -r /dev/urandom -a HMAC-MD5 -b 512 -n HOST omapi_key
 cat Komapi_key.+*.private |grep ^Key|cut -d ' ' -f2-
 </pre>


### PR DESCRIPTION
Hope this workflow digram explains how the VM gets provisioned on a compute node such as oVirt and configuration management like salt.

Kind Regards,
Sherif
![workflow](https://cloud.githubusercontent.com/assets/1666001/5508035/9a9b99e0-87a0-11e4-814f-86ec52e1b16a.jpg)
